### PR TITLE
Update ScalingImageView to latest version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     implementation 'com.android.support:palette-v7:27.0.2'
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.github.markusfisch:ScalingImageView:1.0.1'
+    compile 'com.github.markusfisch:ScalingImageView:1.1.2'
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.android.support:cardview-v7:27.0.2'
     compile 'com.android.support:design:27.0.2'

--- a/app/src/main/java/de/cineaste/android/activity/MoviePosterActivity.java
+++ b/app/src/main/java/de/cineaste/android/activity/MoviePosterActivity.java
@@ -36,7 +36,7 @@ public class MoviePosterActivity extends AppCompatActivity {
 
         moviePoster = new ScalingImageView(this);
         setTransitionNameIfNecessary();
-        moviePoster.setImageDrawable(getResources().getDrawable(R.drawable.placeholder_poster));
+        moviePoster.setImageResource(drawable.placeholder_poster);
         setContentView(moviePoster);
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);


### PR DESCRIPTION
Keeps transformation when the image is changed (if it has the same
aspect ratio and rotation setting).

And use ImageView.setImageResource() for resources.
No need to getResources().getDrawable() when there is setImageResource().
Also, getDrawable() is deprecated.